### PR TITLE
Revert none javadoc from #36

### DIFF
--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/KilometerPerHour.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/KilometerPerHour.java
@@ -10,10 +10,12 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class KilometerPerHour extends Speed {
+public class KilometerPerHour implements Speed {
+	private final float speed;
 
 	public KilometerPerHour(float speed) {
-		super(speed);
+
+		this.speed = speed;
 	}
 
 	/**
@@ -29,7 +31,7 @@ public class KilometerPerHour extends Speed {
 	 * @return speed in meter per second
 	 */
 	public Speed toMeterPerSecond() {
-		return new MeterPerSecond(getSpeed() / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
+		return new MeterPerSecond(speed / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -37,7 +39,7 @@ public class KilometerPerHour extends Speed {
 	 * @return speed in mile per hour
 	 */
 	public Speed toMilePerHour() {
-		return new MilePerHour(getSpeed() / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
+		return new MilePerHour(speed / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -45,6 +47,6 @@ public class KilometerPerHour extends Speed {
 	 * @return speed in knot
 	 */
 	public Speed toKnot() {
-		return new Knot(getSpeed() / Speed.KNOT_TO_KILOMETER_PER_HOUR);
+		return new Knot(speed / Speed.KNOT_TO_KILOMETER_PER_HOUR);
 	}
 }

--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/Knot.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/Knot.java
@@ -10,10 +10,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class Knot extends Speed {
+public class Knot implements Speed {
+	private final float speed;
 
 	public Knot(float speed) {
-		super(speed);
+
+		this.speed = speed;
 	}
 
 	/**
@@ -21,7 +23,7 @@ public class Knot extends Speed {
 	 * @return speed in kilometer per hour
 	 */
 	public Speed toKilometerPerHour() {
-		return new KilometerPerHour(getSpeed() * Speed.KNOT_TO_KILOMETER_PER_HOUR);
+		return new KilometerPerHour(speed * Speed.KNOT_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -29,7 +31,7 @@ public class Knot extends Speed {
 	 * @return speed in meter per second
 	 */
 	public Speed toMeterPerSecond() {
-		return new MeterPerSecond(getSpeed() * Speed.KNOT_TO_KILOMETER_PER_HOUR / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
+		return new MeterPerSecond(speed * Speed.KNOT_TO_KILOMETER_PER_HOUR / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -37,7 +39,7 @@ public class Knot extends Speed {
 	 * @return speed in mile per hour
 	 */
 	public Speed toMilePerHour() {
-		return new MilePerHour(getSpeed() * Speed.KNOT_TO_KILOMETER_PER_HOUR / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
+		return new MilePerHour(speed * Speed.KNOT_TO_KILOMETER_PER_HOUR / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**

--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/MeterPerSecond.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/MeterPerSecond.java
@@ -10,10 +10,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class MeterPerSecond extends Speed {
+public class MeterPerSecond implements Speed {
+	private final float speed;
 
 	public MeterPerSecond(float speed) {
-		super(speed);
+
+		this.speed = speed;
 	}
 
 	/**
@@ -21,7 +23,7 @@ public class MeterPerSecond extends Speed {
 	 * @return speed in kilometer per hour
 	 */
 	public Speed toKilometerPerHour() {
-		return new KilometerPerHour(getSpeed() * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
+		return new KilometerPerHour(speed * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -37,7 +39,7 @@ public class MeterPerSecond extends Speed {
 	 * @return speed in mile per hour
 	 */
 	public Speed toMilePerHour() {
-		return new MilePerHour(getSpeed() * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
+		return new MilePerHour(speed * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR / Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -45,6 +47,6 @@ public class MeterPerSecond extends Speed {
 	 * @return speed in knot
 	 */
 	public Speed toKnot() {
-		return new Knot(getSpeed() * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR / Speed.KNOT_TO_KILOMETER_PER_HOUR);
+		return new Knot(speed * Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR / Speed.KNOT_TO_KILOMETER_PER_HOUR);
 	}
 }

--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/MilePerHour.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/MilePerHour.java
@@ -44,9 +44,4 @@ public class MilePerHour extends Speed {
 	public Speed toKnot() {
 		return new Knot(getSpeed() * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR / Speed.KNOT_TO_KILOMETER_PER_HOUR);
 	}
-
-	@Override
-	public float getSpeed() {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/MilePerHour.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/MilePerHour.java
@@ -7,10 +7,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class MilePerHour extends Speed {
+public class MilePerHour implements Speed {
+	private final float speed;
 
 	public MilePerHour(float speed) {
-		super(speed);
+
+		this.speed = speed;
 	}
 
 	/**
@@ -18,7 +20,7 @@ public class MilePerHour extends Speed {
 	 * @return speed in kilometer per hour
 	 */
 	public Speed toKilometerPerHour() {
-		return new KilometerPerHour(getSpeed() * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
+		return new KilometerPerHour(speed * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -26,7 +28,7 @@ public class MilePerHour extends Speed {
 	 * @return speed in meter per second
 	 */
 	public Speed toMeterPerSecond() {
-		return new MeterPerSecond(getSpeed() * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
+		return new MeterPerSecond(speed * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR / Speed.METER_PER_SECOND_TO_KILOMETER_PER_HOUR);
 	}
 
 	/**
@@ -42,6 +44,6 @@ public class MilePerHour extends Speed {
 	 * @return speed in knot
 	 */
 	public Speed toKnot() {
-		return new Knot(getSpeed() * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR / Speed.KNOT_TO_KILOMETER_PER_HOUR);
+		return new Knot(speed * Speed.MILE_PER_HOUR_TO_KILOMETER_PER_HOUR / Speed.KNOT_TO_KILOMETER_PER_HOUR);
 	}
 }

--- a/src/main/java/segelzwerg/sporttooolbox/IUnits/Speed.java
+++ b/src/main/java/segelzwerg/sporttooolbox/IUnits/Speed.java
@@ -3,40 +3,32 @@ package segelzwerg.sporttooolbox.IUnits;
 /**
  * Speed interface
  */
-public abstract class Speed {
+public interface Speed {
 
 	public static final float METER_PER_SECOND_TO_KILOMETER_PER_HOUR = 3.6f;
 	public static final float MILE_PER_HOUR_TO_KILOMETER_PER_HOUR = 1.609344f;
 	public static final float KNOT_TO_KILOMETER_PER_HOUR = 1.852f;
 
-	private float speed;
-	
-	public Speed(float speed) {
-		this.speed = speed;
-	}
-
 	/**
 	 * Convert to kilometer per hour
 	 * @return speed in kilometer per hour
 	 */
-	public abstract Speed toKilometerPerHour();
+    Speed toKilometerPerHour();
 	/**
 	 * Convert to meter per second
 	 * @return speed in meter per second
 	 */
-	public abstract Speed toMeterPerSecond();
+    Speed toMeterPerSecond();
 	/**
 	 * Convert to mile per hour
 	 * @return speed in mile per hour
 	 */
-	public abstract Speed toMilePerHour();
+    Speed toMilePerHour();
 	/**
 	 * Convert to knot
 	 * @return speed in knot
 	 */
-	public abstract Speed toKnot();
+    Speed toKnot();
 
-    float getSpeed() {
-    	return speed;
-    }
+    float getSpeed();
 }

--- a/src/test/java/segelzwerg/sporttooolbox/IUnits/MilePerHourTest.java
+++ b/src/test/java/segelzwerg/sporttooolbox/IUnits/MilePerHourTest.java
@@ -11,7 +11,11 @@ public class MilePerHourTest {
 
     private static final float THIRTY_MILES_PER_HOUR = 30f;
     private static Speed thirtyMilesPerHour;
-
+    
+    /**
+     * Set up before all tests
+     * Initialization of static Speed thirtyMilesPerHour
+     */
     @BeforeClass
     public static void setUp() {
         thirtyMilesPerHour = new MilePerHour(THIRTY_MILES_PER_HOUR);

--- a/src/test/java/segelzwerg/sporttooolbox/IUnits/MilePerHourTest.java
+++ b/src/test/java/segelzwerg/sporttooolbox/IUnits/MilePerHourTest.java
@@ -12,10 +12,6 @@ public class MilePerHourTest {
     private static final float THIRTY_MILES_PER_HOUR = 30f;
     private static Speed thirtyMilesPerHour;
 
-    /**
-     * Set up before all tests
-     * Initialization of static Speed thirtyMilesPerHour
-     */
     @BeforeClass
     public static void setUp() {
         thirtyMilesPerHour = new MilePerHour(THIRTY_MILES_PER_HOUR);


### PR DESCRIPTION
The reason for the revert was that the Speed is an interface not an abstract class. In addition to that it is far more easier to maintain a project if the commits in a PR are logically connected. It is easier if there are more PRs but less commits in them.