### PR TITLE
FIX: speed calculator use minutes and seconds now

### DIFF
--- a/src/main/java/segelzwerg/sporttooolbox/Controller/SpeedService.java
+++ b/src/main/java/segelzwerg/sporttooolbox/Controller/SpeedService.java
@@ -25,7 +25,7 @@ public class SpeedService {
         int hour = form.getHour();
         int minute = form.getMinute();
         int second = form.getSecond();
-        Time time = new Time(hour);
+        Time time = new Time(hour, minute, second);
 
         SpeedCalculator speedCalculator = new SpeedCalculator(distance, time);
 

--- a/src/main/resources/templates/SpeedForm.html
+++ b/src/main/resources/templates/SpeedForm.html
@@ -63,8 +63,10 @@
                     <h5 class="card-title">Speed</h5>
                     <p class="card-text">
                         The average speed is <span th:text="${speed?.kilometerPerHour.speed}">30</span> km/h
-                        for travelling <span th:text="${form.kilometer}">30</span> kilometer in
-                        <span th:text="${form.hour}">1</span> hour.
+                        for travelling <span th:text="${form.kilometer}">30</span> kilometer and <span
+                            th:text="${form.meter}">0</span> meter in
+                        <span th:text="${form.hour}">1</span> hour, <span th:text="${form.minute}">0</span> minute
+                        <span th:text="${form.second}">0</span> seconds.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
ADD: the page displays minutes and seconds now

fix #38

Signed-off-by: Marcel <marcel.haas@hhu.de>
